### PR TITLE
Features/separate metadata into columns

### DIFF
--- a/src/vecs/adapter/noop.py
+++ b/src/vecs/adapter/noop.py
@@ -38,9 +38,9 @@ class NoOp(AdapterStep):
 
     def __call__(
         self,
-        records: Iterable[Tuple[str, Any, Optional[Dict], Optional[str]]],
+        records: Iterable[Tuple[str, Any, Optional[Dict], Optional[str], Optional[int], Optional[int]]],
         adapter_context: AdapterContext,
-    ) -> Generator[Tuple[str, Any, Dict, str], None, None]:
+    ) -> Generator[Tuple[str, Any, Dict, str, int, int], None, None]:
         """
         Yields the input records without any modification.
 
@@ -49,7 +49,7 @@ class NoOp(AdapterStep):
             adapter_context: Context of the adapter.
 
         Yields:
-            Tuple[str, Any, Dict, str]: The input record.
+            Tuple[str, Any, Dict, str, int, int]: The input record.
         """
-        for id, media, metadata, text in records:
-            yield (id, media, metadata or {}, text or None)
+        for id, media, metadata, text, document_id, order in records:
+            yield (id, media, metadata or {}, text or None, document_id, order)

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -944,7 +944,7 @@ def build_table(name: str, meta: MetaData, dimension: int) -> Table:
             nullable=False,
         ),
         Column("text", Text, nullable=True),
-        Column("document_id", BIGINT, nullable=False),
-        Column("order", BIGINT, nullable=False),
+        Column("document_id", BIGINT, nullable=False, index=True),
+        Column("order", BIGINT, nullable=False, index=True),
         extend_existing=True,
     )

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -263,6 +263,27 @@ class Collection:
         if not collection_dimension:
             self.table.create(self.client.engine)
 
+            with self.client.Session() as sess:
+                sess.execute(
+                    text(
+                        f"""
+                        create index {self.name}_ix_document_id
+                          on vecs."{self.name}"
+                          using btree ( document_id )
+                        """
+                    )
+                )
+                sess.execute(
+                    text(
+                        f"""
+                        create index {self.name}_ix_order
+                          on vecs."{self.name}"
+                          using btree ( "order" )
+                        """
+                    )
+                )
+                sess.commit()
+
         return self
 
     def _create(self):
@@ -944,7 +965,7 @@ def build_table(name: str, meta: MetaData, dimension: int) -> Table:
             nullable=False,
         ),
         Column("text", Text, nullable=True),
-        Column("document_id", BIGINT, nullable=False, index=True),
-        Column("order", BIGINT, nullable=False, index=True),
+        Column("document_id", BIGINT, nullable=True),
+        Column("order", BIGINT, nullable=True),
         extend_existing=True,
     )


### PR DESCRIPTION
# Descriptions:
 - Separate metadata into 2 columns (with index) for filtering purposes (document_id, and order)