### PR TITLE
256 - OpenAI GPT got internal server error (500) while calling our API.

### DIFF
--- a/src/vecs/client.py
+++ b/src/vecs/client.py
@@ -57,7 +57,7 @@ class Client:
         Returns:
             None
         """
-        self.engine = create_engine(connection_string, pool_size=0)
+        self.engine = create_engine(connection_string, pool_size=0, pool_pre_ping=True)
         self.meta = MetaData(schema="vecs")
         self.Session = sessionmaker(self.engine)
 


### PR DESCRIPTION
### Title: [256 - OpenAI GPT got internal server error (500) while calling our API](https://www.pivotaltracker.com/story/show/186951256)

### Description:

Sometimes, after a long period of inactivity, connection to the DB would fail. In our backend, we have retry mechanism, so this is not a problem. But this is not the case for GPTs. 

Adding the argument `pool_pre_ping=True` when creating the `sqlalchemy` engine should fix this.

We can see when this error occurs in New Relic: https://onenr.io/0gR743BDWjo

When this change is deployed to production, we will monitor this log to see if the issue is fixed.